### PR TITLE
New domain unload fix. Reverting PR #2 changes

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -52,7 +52,6 @@ namespace Mono.Debugging.Soft
 	{
 		readonly Dictionary<Tuple<TypeMirror, string>, MethodMirror[]> overloadResolveCache = new Dictionary<Tuple<TypeMirror, string>, MethodMirror[]> ();
 		readonly Dictionary<string, List<TypeMirror>> source_to_type = new Dictionary<string, List<TypeMirror>> (PathComparer);
-		readonly Dictionary<AppDomainMirror, AssemblyMirror[]> domainAssemblies = new Dictionary<AppDomainMirror, AssemblyMirror[]>();
 		readonly Dictionary<long,ObjectMirror> activeExceptionsByThread = new Dictionary<long, ObjectMirror> ();
 		readonly Dictionary<EventRequest, BreakInfo> breakpoints = new Dictionary<EventRequest, BreakInfo> ();
 		readonly Dictionary<string, MonoSymbolFile> symbolFiles = new Dictionary<string, MonoSymbolFile> ();
@@ -418,8 +417,8 @@ namespace Mono.Debugging.Soft
 			ConnectOutput (machine.StandardError, true);
 			
 			HideConnectionDialog ();
-
-			machine.EnableEvents (EventType.AppDomainCreate, EventType.AppDomainUnload, EventType.AssemblyLoad, EventType.ThreadStart, EventType.ThreadDeath,
+			
+			machine.EnableEvents (EventType.AssemblyLoad, EventType.ThreadStart, EventType.ThreadDeath,
 				EventType.AssemblyUnload, EventType.UserBreak, EventType.UserLog);
 			try {
 				unhandledExceptionRequest = machine.CreateExceptionRequest (null, false, true);
@@ -1456,12 +1455,6 @@ namespace Mono.Debugging.Soft
 			}
 
 			switch (type) {
-			case EventType.AppDomainCreate:
-				HandleAppDomainCreateEvents (Array.ConvertAll(es.Events, item => (AppDomainCreateEvent)item));
-				break;
-			case EventType.AppDomainUnload:
-				HandleAppDomainUnloadEvents (Array.ConvertAll(es.Events, item => (AppDomainUnloadEvent)item));
-				break;
 			case EventType.AssemblyLoad:
 				HandleAssemblyLoadEvents (Array.ConvertAll (es.Events, item => (AssemblyLoadEvent)item));
 				break;
@@ -1796,59 +1789,6 @@ namespace Mono.Debugging.Soft
 			}
 		}
 
-		void RemoveUnloadedAssemblyTypes(AssemblyMirror asm)
-		{
-			// Remove affected types from the loaded types list
-			var affectedTypes = new List<string>(from pair in types
-												 where PathComparer.Equals(pair.Value.Assembly.Location, asm.Location)
-												 select pair.Key);
-
-			foreach (string typeName in affectedTypes)
-			{
-				TypeMirror tm;
-
-				if (types.TryGetValue(typeName, out tm))
-				{
-					if (tm.IsNested)
-						aliases.Remove(NestedTypeNameToAlias(typeName));
-
-					types.Remove(typeName);
-				}
-			}
-
-			foreach (var pair in source_to_type)
-			{
-				pair.Value.RemoveAll(m => PathComparer.Equals(m.Assembly.Location, asm.Location));
-			}
-		}
-
-		void HandleAppDomainCreateEvents(AppDomainCreateEvent[] events)
-		{
-			var domain = events[0].Domain;
-			if (events.Length > 1)
-				throw new InvalidOperationException("Simultaneous AppDomainCreateEvent for multiple domains");
-
-			if(!domainAssemblies.ContainsKey(domain))
-				domainAssemblies[domain] = null;
-		}
-
-		void HandleAppDomainUnloadEvents(AppDomainUnloadEvent[] events)
-		{
-			var domain = events[0].Domain;
-			if (events.Length > 1)
-				throw new InvalidOperationException("Simultaneous AppDomainUnloadEvent for multiple domains");
-
-			if (!domainAssemblies.ContainsKey(domain))
-				return;
-
-			var assemblies = domainAssemblies[domain];
-
-			foreach (var asm in assemblies)
-				RemoveUnloadedAssemblyTypes(asm);
-
-			domainAssemblies.Remove(domain);
-		}
-
 		void HandleAssemblyLoadEvents (AssemblyLoadEvent[] events)
 		{
 			var asm = events [0].Assembly;
@@ -1862,11 +1802,6 @@ namespace Mono.Debugging.Soft
 
 			string flagExt = isExternal ? " [External]" : "";
 			OnDebuggerOutput (false, string.Format ("Loaded assembly: {0}{1}\n", asm.Location, flagExt));
-
-			// Update loaded assemblies for each domain
-			var domains = new List<AppDomainMirror>(domainAssemblies.Keys);
-			foreach (var domain in domains)
-				domainAssemblies[domain] = domain.GetAssemblies();
 		}
 
 		void HandleAssemblyUnloadEvents (AssemblyUnloadEvent[] events)
@@ -1894,7 +1829,25 @@ namespace Mono.Debugging.Soft
 					pending_bes.Add (breakpoint.Value);
 				}
 
-				RemoveUnloadedAssemblyTypes(asm);
+				// Remove affected types from the loaded types list
+				var affectedTypes = new List<string> (from pair in types
+					 where PathComparer.Equals (pair.Value.Assembly.Location, asm.Location)
+					 select pair.Key);
+
+				foreach (string typeName in affectedTypes) {
+					TypeMirror tm;
+
+					if (types.TryGetValue (typeName, out tm)) {
+						if (tm.IsNested)
+							aliases.Remove (NestedTypeNameToAlias (typeName));
+
+						types.Remove (typeName);
+					}
+				}
+
+				foreach (var pair in source_to_type) {
+					pair.Value.RemoveAll (m => PathComparer.Equals (m.Assembly.Location, asm.Location));
+				}
 			}
 			OnDebuggerOutput (false, string.Format ("Unloaded assembly: {0}\n", asm.Location));
 		}


### PR DESCRIPTION
Reverting https://github.com/Unity-Technologies/debugger-libs/pull/2 changes, as it had the unwanted side-effect of unloading all types in most cases.

This fix explicitly checks in GetType whether an mscorlib type has been unloaded in the debugger agent and returns null. The callers of GetType fall back to different approaches for getting the type if GetType returns null.

Fixes case 719009
