### PR TITLE
Workaround: Ignore ERR_UNLOADED error when disabling/enabling breakpoint

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1081,7 +1081,13 @@ namespace Mono.Debugging.Soft
 				var bi = (BreakInfo) eventInfo;
 				if (bi.Requests.Count != 0) {
 					foreach (var request in bi.Requests)
-						request.Enabled = enable;
+					{
+						try
+						{
+							request.Enabled = enable;
+						}
+						catch { }
+					}
 
 					if (!enable)
 						RemoveQueuedBreakEvents (bi.Requests);


### PR DESCRIPTION
When enabling and disabling an breakpoint after a domain unload MonoDevelop will show a dialog with "ERR_UNLOADED" error due to incorrect handling of domain unloads.

Fixing this issue with a work around until we there is proper handling for domain unloads in the soft debugger libs.

Fixes case 588431
