### PR TITLE
Revert commits that require assembly unload fix in debugger agent.

### DIFF
--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1082,7 +1082,11 @@ namespace Mono.Debugging.Soft
 				if (bi.Requests.Count != 0) {
 					foreach (var request in bi.Requests)
 					{
-						request.Enabled = enable;
+						try
+						{
+							request.Enabled = enable;
+						}
+						catch { }
 					}
 
 					if (!enable)
@@ -1860,7 +1864,6 @@ namespace Mono.Debugging.Soft
 					int line = breakpoint.Value.Location.LineNumber;
 					OnDebuggerOutput (false, string.Format ("Re-pending breakpoint at {0}:{1}\n", file, line));
 					breakpoints.Remove (breakpoint.Key);
-					breakpoint.Value.Requests.Clear ();
 					pending_bes.Add (breakpoint.Value);
 				}
 

--- a/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -56,7 +56,6 @@ namespace Mono.Debugging.Soft
 		readonly Dictionary<EventRequest, BreakInfo> breakpoints = new Dictionary<EventRequest, BreakInfo> ();
 		readonly Dictionary<string, MonoSymbolFile> symbolFiles = new Dictionary<string, MonoSymbolFile> ();
 		readonly Dictionary<string, string> symbolFileCopies = new Dictionary<string, string> ();
-		readonly Dictionary<AssemblyMirror, string> assemblyLocations = new Dictionary<AssemblyMirror, string>();
 		readonly Dictionary<TypeMirror, string[]> type_to_source = new Dictionary<TypeMirror, string[]> ();
 		readonly Dictionary<string, TypeMirror> aliases = new Dictionary<string, TypeMirror> ();
 		readonly Dictionary<string, TypeMirror> types = new Dictionary<string, TypeMirror> ();
@@ -1833,7 +1832,6 @@ namespace Mono.Debugging.Soft
 			bool isExternal;
 			lock (pending_bes) {
 				isExternal = !UpdateAssemblyFilters (asm) && userAssemblyNames != null;
-				assemblyLocations[asm] = asm.Location;
 			}
 
 			string flagExt = isExternal ? " [External]" : "";
@@ -1843,16 +1841,6 @@ namespace Mono.Debugging.Soft
 		void HandleAssemblyUnloadEvents (AssemblyUnloadEvent[] events)
 		{
 			var asm = events [0].Assembly;
-			String asmLocation;
-
-			lock (pending_bes)
-			{
-				if (!assemblyLocations.TryGetValue(asm, out asmLocation))
-					return;
-
-				assemblyLocations.Remove(asm);
-			}
-
 			if (events.Length > 1 && events.Any (a => a.Assembly != asm))
 				throw new InvalidOperationException ("Simultaneous AssemblyUnloadEvents for multiple assemblies");
 
@@ -1865,7 +1853,7 @@ namespace Mono.Debugging.Soft
 				// Mark affected breakpoints as pending again
 				var affectedBreakpoints = new List<KeyValuePair<EventRequest, BreakInfo>> (breakpoints.Where (x => x.Value != null && x.Value.Location != null &&
 					x.Value.Location.Method != null && x.Value.Location.Method.DeclaringType != null &&  x.Value.Location.Method.DeclaringType.Assembly != null &&
-					PathComparer.Equals (x.Value.Location.Method.DeclaringType.Assembly.Location, asmLocation)
+					PathComparer.Equals (x.Value.Location.Method.DeclaringType.Assembly.Location, asm.Location)
 				));
 				foreach (var breakpoint in affectedBreakpoints) {
 					string file = breakpoint.Value.Location.SourceFile;
@@ -1878,7 +1866,7 @@ namespace Mono.Debugging.Soft
 
 				// Remove affected types from the loaded types list
 				var affectedTypes = new List<string> (from pair in types
-					 where PathComparer.Equals (pair.Value.Assembly.Location, asmLocation)
+					 where PathComparer.Equals (pair.Value.Assembly.Location, asm.Location)
 					 select pair.Key);
 
 				foreach (string typeName in affectedTypes) {
@@ -1893,10 +1881,10 @@ namespace Mono.Debugging.Soft
 				}
 
 				foreach (var pair in source_to_type) {
-					pair.Value.RemoveAll (m => PathComparer.Equals (m.Assembly.Location, asmLocation));
+					pair.Value.RemoveAll (m => PathComparer.Equals (m.Assembly.Location, asm.Location));
 				}
 			}
-			OnDebuggerOutput (false, string.Format ("Unloaded assembly: {0}\n", asmLocation));
+			OnDebuggerOutput (false, string.Format ("Unloaded assembly: {0}\n", asm.Location));
 		}
 
 		void HandleVMStartEvents (VMStartEvent[] events)


### PR DESCRIPTION
Need to revert these changes due to this being reverted: 

https://github.com/Unity-Technologies/mono/commit/a2f6838fa8ed82fe4b7a153ef9c9b682f23d84d8
https://github.com/Unity-Technologies/mono/commit/fff0b99e808b2001531f1e23649e0ade8073d381
